### PR TITLE
Fix install.sh: set -e, btrfs-progs, /etc/hosts, localectl im chroot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #Festplatte wählen
 echo "Verfügbare Festplatten:"
@@ -71,7 +72,7 @@ mount -t btrfs -o subvol=@home,compress=zstd $PART2 /mnt/home
 mount -t btrfs -o subvol=@snapshots,compress=zstd $PART2 /mnt/.snapshots
 
 #Basissystem installieren
-pacstrap -K /mnt base linux linux-firmware vim sudo
+pacstrap -K /mnt base linux linux-firmware vim sudo btrfs-progs
 
 #Mirrorlist ins Livesystem kopieren
 cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist
@@ -89,12 +90,14 @@ hwclock --systohc
 #Sprache im Livesystem setzen
 echo "de_DE.UTF-8 UTF-8" > /etc/locale.gen
 locale-gen
-localectl set-x11-keymap de
 echo "LANG=de_DE.UTF-8" > /etc/locale.conf
 echo "KEYMAP=de-latin1" > /etc/vconsole.conf
 
 #Hostname setzen
 echo "$HOSTNAME" > /etc/hostname
+echo "127.0.0.1 localhost" > /etc/hosts
+echo "::1       localhost" >> /etc/hosts
+echo "127.0.1.1 $HOSTNAME.localdomain $HOSTNAME" >> /etc/hosts
 
 #Root Passwort setzen
 echo "root:$ROOTPASS" | chpasswd


### PR DESCRIPTION
- add set -e damit Fehler das Skript abbrechen
- btrfs-progs zu pacstrap hinzufügen (nötig für Btrfs-Userspace-Tools)
- /etc/hosts generieren (localhost-Auflösung ohne Datei defekt)
- localectl set-x11-keymap entfernen (kein D-Bus im chroot; Hyprland setzt kb_layout=de bereits selbst)

https://claude.ai/code/session_0143vTGnJ5oHgQHkqE5jaMyP