### PR TITLE
Fix install.sh: Festplattenname-Eingabe robuster machen

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,18 @@ set -e
 echo "Verfügbare Festplatten:"
 lsblk -d -o NAME,SIZE,TYPE | grep disk
 echo ""
-read -p "Festplattenname eingeben (z.b. sda, vda, nvme0n1): " DISKNAME
+read -rp "Festplattenname eingeben (z.b. sda, vda, nvme0n1): " DISKNAME
+
+# Whitespace entfernen und führendes /dev/ abschneiden falls angegeben
+DISKNAME="${DISKNAME//[[:space:]]/}"
+DISKNAME="${DISKNAME#/dev/}"
 DISK="/dev/$DISKNAME"
 
 #Prüfen ob Disk existiert
 if [ ! -b "$DISK" ]; then
   echo "Fehler: $DISK existiert nicht!"
+  echo "Verfügbare Festplatten:"
+  lsblk -d -o NAME,SIZE,TYPE | grep disk
   exit 1
 fi
 


### PR DESCRIPTION
- read -rp statt read -p (korrekte Backslash-Behandlung)
- Whitespace aus DISKNAME entfernen
- Führendes /dev/ abschneiden falls Nutzer /dev/sda statt sda eingibt
- Bei Fehler verfügbare Festplatten erneut anzeigen

https://claude.ai/code/session_01EyhQfrPCPNAg63gv6PvUMH